### PR TITLE
Add schema.sql and data.sql for item

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -134,4 +134,8 @@ class App
       end
     end
   end
+
+
+
+  
 end

--- a/database/data.sql
+++ b/database/data.sql
@@ -1,0 +1,4 @@
+
+INSERT into items (publish_date, archived, author_id) values ("1999", false)
+INSERT into items (publish_date, archived, author_id) values ("2000", false)
+

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,10 @@
+
+CREATE TABLE items (
+  id int generated always as identity,
+  publish_date date,
+  archived boolean,
+  genre_id int,
+  author_id int,
+  label_id int,
+  PRIMARY KEY (id)
+)


### PR DESCRIPTION
In this pull request, @yetemegn-telaye , @Dmambo and I (@Trast00 ) have been able to::
- Add `schema.sql` with `items` table schema
- Add `data.sql` with `items` data insertion